### PR TITLE
Updated .language_drop_down

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -33,7 +33,7 @@ body {
 .language__drop__down {
     background: transparent;
     border: none;
-    color: white;
+    color: #757575;
 }
 
 .language__drop__down:focus {


### PR DESCRIPTION
changed colour from white to #757575 as text was showing when selecting a language as it was blending in with the white selection colours, however changed to grey to solve issue.